### PR TITLE
Launcher3: Allow hiding top shadow on statusbar

### DIFF
--- a/res/values/lineage_strings.xml
+++ b/res/values/lineage_strings.xml
@@ -61,4 +61,7 @@
     <!-- App suggestions -->
     <string name="pref_suggestions_title">Suggestions</string>
     <string name="pref_suggestions_summary">For app drawer &amp; home screen suggestions</string>
+
+    <!-- Top shadow -->
+    <string name="show_top_shadow">Top shadow</string>
 </resources>

--- a/res/xml/launcher_preferences.xml
+++ b/res/xml/launcher_preferences.xml
@@ -141,6 +141,13 @@
         android:persistent="true" />
 
     <SwitchPreferenceCompat
+        android:key="pref_show_top_shadow"
+        android:title="@string/show_top_shadow"
+        android:defaultValue="true"
+        android:persistent="true"
+        launcher:iconSpaceReserved="false" />
+
+    <SwitchPreferenceCompat
         android:key="pref_drawer_show_labels"
         android:title="@string/drawer_show_labels"
         android:defaultValue="true"


### PR DESCRIPTION
On certain devices (especially amoled) with certain black-themed wallpapers, it looks quite bad. Add a toggle to disable it, inspired from lawnchair:

https://github.com/LawnchairLauncher/lawnchair/commit/c99e61205cc4d5b5d3d9b827787c9fd873616060 https://github.com/LawnchairLauncher/lawnchair/commit/e41e27a4d11e7f8352a3d2fa74afb04e8af9354a

Squashed:

    From: Adithya R <gh0strider.2k18.reborn@gmail.com>
    Date: Sun, 10 Nov 2024 22:54:28 +0530
    Subject: fixup! Launcher3: Allow hiding top shadow on statusbar

    Change-Id: I962faf5586eb9493d1bf69bcdf4652f4c62f9d1e
    Signed-off-by: Pranav Vashi <neobuddy89@gmail.com>


Change-Id: I2302bb4754a2c087e302a107faca69406b3658d9