### PR TITLE
Launcher3: Do not wrap icons from icon pack

### DIFF
--- a/src/com/android/launcher3/Utilities.java
+++ b/src/com/android/launcher3/Utilities.java
@@ -18,6 +18,7 @@ package com.android.launcher3;
 
 import static com.android.launcher3.BuildConfig.WIDGET_ON_FIRST_SCREEN;
 import static com.android.launcher3.Flags.enableSmartspaceAsAWidget;
+import static com.android.launcher3.icons.BaseIconFactory.CONFIG_HINT_NO_WRAP;
 import static com.android.launcher3.graphics.ShapeDelegate.DEFAULT_PATH_SIZE;
 import static com.android.launcher3.icons.BitmapInfo.FLAG_THEMED;
 import static com.android.launcher3.util.SplitConfigurationOptions.STAGE_POSITION_BOTTOM_OR_RIGHT;
@@ -696,10 +697,10 @@ public final class Utilities {
         if (mainIcon == null) {
             return null;
         }
-        AdaptiveIconDrawable result;
+        AdaptiveIconDrawable result = null;
         if (mainIcon instanceof AdaptiveIconDrawable aid) {
             result = aid;
-        } else {
+        } else if ((mainIcon.getChangingConfigurations() & CONFIG_HINT_NO_WRAP) == 0) {
             // Wrap the main icon in AID
             try (LauncherIcons li = LauncherIcons.obtain(context)) {
                 result = li.wrapToAdaptiveIcon(mainIcon);


### PR DESCRIPTION
Otherwise we get a circle background during app/close animation or while dragging the shortcut.

Change-Id: Ie3741c2d52c5460e8be8609264cb364d2d3ecabb