### PR TITLE
StashedHandleView: add gestural burn in protection

### DIFF
--- a/quickstep/src/com/android/launcher3/taskbar/StashedHandleViewController.java
+++ b/quickstep/src/com/android/launcher3/taskbar/StashedHandleViewController.java
@@ -33,6 +33,8 @@ import android.content.Context;
 import android.content.res.Resources;
 import android.graphics.Outline;
 import android.graphics.Rect;
+import android.os.Handler;
+import android.os.Looper;
 import android.view.View;
 import android.view.ViewOutlineProvider;
 
@@ -57,6 +59,8 @@ import com.android.systemui.shared.system.TaskStackChangeListeners;
 import com.android.wm.shell.shared.handles.RegionSamplingHelper;
 
 import java.io.PrintWriter;
+import java.util.Timer;
+import java.util.TimerTask;
 
 /**
  * Handles properties/data collection, then passes the results to our stashed handle View to render.
@@ -100,6 +104,18 @@ public class StashedHandleViewController implements TaskbarControllers.LoggableT
     private TaskbarControllers mControllers;
     private int mTaskbarSize;
 
+    // Burn-in protection
+    private Timer mBurnInTimer;
+    private float mTranslationXForBurnIn;
+    private float mTranslationYForBurnIn;
+    private float mHorizontalMaxShift;
+    private float mVerticalMaxShift;
+    private float mHorizontalShiftStep;
+    private float mVerticalShiftStep;
+    private final Handler mUiHandler = new Handler(Looper.getMainLooper());
+    private boolean mBurnInProtectionEnabled;
+    private long mBurnInShiftIntervalMs;
+
     // The bounds we want to clip to in the settled state when showing the stashed handle.
     private final Rect mStashedHandleBounds = new Rect();
     private float mStashedHandleRadius;
@@ -131,6 +147,14 @@ public class StashedHandleViewController implements TaskbarControllers.LoggableT
         final Resources resources = mActivity.getResources();
         mStashedHandleHeight = resources.getDimensionPixelSize(
                 R.dimen.taskbar_stashed_handle_height);
+        mBurnInProtectionEnabled = resources.getBoolean(R.bool.config_enableBurnInProtection);
+        mBurnInShiftIntervalMs = resources.getInteger(R.integer.config_burnInProtectionShiftInterval) * 1000L;
+
+        mHorizontalMaxShift = resources.getDimension(R.dimen.burn_in_protection_horizontal_shift);
+        mVerticalMaxShift = resources.getDimension(R.dimen.burn_in_protection_vertical_shift);
+
+        mHorizontalShiftStep = mHorizontalMaxShift / 3f;
+        mVerticalShiftStep = mVerticalMaxShift / 3f;
     }
 
     public void init(TaskbarControllers controllers) {
@@ -198,6 +222,7 @@ public class StashedHandleViewController implements TaskbarControllers.LoggableT
             TaskStackChangeListeners.getInstance().registerTaskStackListener(
                     mTaskStackChangeListener);
         }
+        startBurnInTimer();
     }
 
     /**
@@ -235,6 +260,7 @@ public class StashedHandleViewController implements TaskbarControllers.LoggableT
             TaskStackChangeListeners.getInstance().unregisterTaskStackListener(
                     mTaskStackChangeListener);
         }
+        stopBurnInTimer();
     }
 
     public MultiValueAlpha getStashedHandleAlpha() {
@@ -346,7 +372,8 @@ public class StashedHandleViewController implements TaskbarControllers.LoggableT
     }
 
     private void updateTranslationY() {
-        mStashedHandleView.setTranslationY(mTranslationYForSwipe + mTranslationYForStash);
+        mStashedHandleView.setTranslationX(mTranslationXForBurnIn);
+        mStashedHandleView.setTranslationY(mTranslationYForSwipe + mTranslationYForStash + mTranslationYForBurnIn);
     }
 
     /**
@@ -436,5 +463,42 @@ public class StashedHandleViewController implements TaskbarControllers.LoggableT
     @Override
     public Rect getBoundsOnScreen() {
         return mStashedHandleView.getSampledRegion();
+    }
+    private void startBurnInTimer() {
+        if (!mBurnInProtectionEnabled || mBurnInTimer != null)
+		return;
+
+        mBurnInTimer = new Timer();
+        mBurnInTimer.schedule(new TimerTask() {
+            @Override
+            public void run() {
+                mUiHandler.post(() -> shiftHandle());
+            }
+        }, 0, mBurnInShiftIntervalMs);
+    }
+
+    private void stopBurnInTimer() {
+        if (mBurnInTimer != null) {
+            mBurnInTimer.cancel();
+            mBurnInTimer = null;
+        }
+    }
+
+    private void shiftHandle() {
+        // Horizontal shift logic
+        mTranslationXForBurnIn += mHorizontalShiftStep;
+        if (mTranslationXForBurnIn >= mHorizontalMaxShift ||
+            mTranslationXForBurnIn <= -mHorizontalMaxShift) {
+            mHorizontalShiftStep *= -1;
+        }
+
+        // Vertical shift logic
+        mTranslationYForBurnIn += mVerticalShiftStep;
+        if (mTranslationYForBurnIn >= mVerticalMaxShift ||
+            mTranslationYForBurnIn <= -mVerticalMaxShift) {
+            mVerticalShiftStep *= -1;
+        }
+
+        updateTranslationY();
     }
 }

--- a/res/values/config.xml
+++ b/res/values/config.xml
@@ -208,6 +208,10 @@
 
     <string-array name="supported_overlay_apps" translatable="false"/>
 
+    <!-- Burn-in protection for gesture navigation handle -->
+    <bool name="config_enableBurnInProtection">true</bool>
+    <integer name="config_burnInProtectionShiftInterval">60</integer>
+
     <!-- Hardcoded game packages for smart drawer categorization 
           Apps that don't report CATEGORY_GAME but should be in Games folder -->
     <string-array name="config_categorize_force_game_packages" translatable="false">

--- a/res/values/dimens.xml
+++ b/res/values/dimens.xml
@@ -608,4 +608,8 @@
     <dimen name="app_title_pill_round_rect_padding">2dp</dimen>
     
     <dimen name="grid_icon_drawable_padding">10.5px</dimen>
+
+    <!-- Burn-in protection shift amounts -->
+    <dimen name="burn_in_protection_horizontal_shift">12dp</dimen>
+    <dimen name="burn_in_protection_vertical_shift">6dp</dimen>
 </resources>


### PR DESCRIPTION
Previously no burn in protection existed since Google moved navbar to L3.

Example of each extreme with these values on waffle: https://i.imgur.com/q7u1BJN.png

However, any device with different criteria may overlay new values.